### PR TITLE
Auto-reveal hint fields if note has a `autoopen::fieldName` tag

### DIFF
--- a/Note Types/AnKing/Back Template.html
+++ b/Note Types/AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
  <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -243,8 +243,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     
@@ -340,15 +340,16 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         extra.classList.add("hidden");
       }
       for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-        if (autoReveal) {
-          const container = document.querySelector(`[data-name="${field}"]`)
+        const container = document.querySelector(`[data-name="${field}"]`)
           if (container) {
-            const link = container.getElementsByTagName("a")[0]
-            const button = container.getElementsByTagName("button")[0]
-            const hint = container.getElementsByTagName("div")[0]
-            button.classList.remove("expanded-button")
-            hint.style.display = "none"
-            link.style.display = ""
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
+              const link = container.getElementsByTagName("a")[0]
+              const button = container.getElementsByTagName("button")[0]
+              const hint = container.getElementsByTagName("div")[0]
+              button.classList.remove("expanded-button")
+              hint.style.display = "none"
+              link.style.display = ""
           }
         }
       }
@@ -460,9 +461,10 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         // Also reveal autoReveal fields
         for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-          if (autoReveal) {
-            const container = document.querySelector(`[data-name="${field}"]`)
-            if (container) {
+          const container = document.querySelector(`[data-name="${field}"]`)
+          if (container) {
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
               const link = container.getElementsByTagName("a")[0]
               const button = container.getElementsByTagName("button")[0]
               const hint = container.getElementsByTagName("div")[0]
@@ -548,6 +550,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/AnKing/Front Template.html
+++ b/Note Types/AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -168,6 +168,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/AnKingDerm/Back Template.html
+++ b/Note Types/AnKingDerm/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -318,8 +318,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     
@@ -415,15 +415,16 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         extra.classList.add("hidden");
       }
       for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-        if (autoReveal) {
-          const container = document.querySelector(`[data-name="${field}"]`)
+        const container = document.querySelector(`[data-name="${field}"]`)
           if (container) {
-            const link = container.getElementsByTagName("a")[0]
-            const button = container.getElementsByTagName("button")[0]
-            const hint = container.getElementsByTagName("div")[0]
-            button.classList.remove("expanded-button")
-            hint.style.display = "none"
-            link.style.display = ""
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
+              const link = container.getElementsByTagName("a")[0]
+              const button = container.getElementsByTagName("button")[0]
+              const hint = container.getElementsByTagName("div")[0]
+              button.classList.remove("expanded-button")
+              hint.style.display = "none"
+              link.style.display = ""
           }
         }
       }
@@ -535,9 +536,10 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         // Also reveal autoReveal fields
         for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-          if (autoReveal) {
-            const container = document.querySelector(`[data-name="${field}"]`)
-            if (container) {
+          const container = document.querySelector(`[data-name="${field}"]`)
+          if (container) {
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
               const link = container.getElementsByTagName("a")[0]
               const button = container.getElementsByTagName("button")[0]
               const hint = container.getElementsByTagName("div")[0]
@@ -623,6 +625,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/AnKingDerm/Front Template.html
+++ b/Note Types/AnKingDerm/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <div id="text">{{cloze:Text}}</div>
 
 
@@ -169,6 +169,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/AnKingMCAT/Back Template.html
+++ b/Note Types/AnKingMCAT/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -276,8 +276,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     
@@ -373,15 +373,16 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         extra.classList.add("hidden");
       }
       for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-        if (autoReveal) {
-          const container = document.querySelector(`[data-name="${field}"]`)
+        const container = document.querySelector(`[data-name="${field}"]`)
           if (container) {
-            const link = container.getElementsByTagName("a")[0]
-            const button = container.getElementsByTagName("button")[0]
-            const hint = container.getElementsByTagName("div")[0]
-            button.classList.remove("expanded-button")
-            hint.style.display = "none"
-            link.style.display = ""
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
+              const link = container.getElementsByTagName("a")[0]
+              const button = container.getElementsByTagName("button")[0]
+              const hint = container.getElementsByTagName("div")[0]
+              button.classList.remove("expanded-button")
+              hint.style.display = "none"
+              link.style.display = ""
           }
         }
       }
@@ -493,9 +494,10 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         // Also reveal autoReveal fields
         for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-          if (autoReveal) {
-            const container = document.querySelector(`[data-name="${field}"]`)
-            if (container) {
+          const container = document.querySelector(`[data-name="${field}"]`)
+          if (container) {
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
               const link = container.getElementsByTagName("a")[0]
               const button = container.getElementsByTagName("button")[0]
               const hint = container.getElementsByTagName("div")[0]
@@ -581,6 +583,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/AnKingMCAT/Front Template.html
+++ b/Note Types/AnKingMCAT/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <div id="text">{{cloze:Text}}</div>
 
 
@@ -174,6 +174,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/AnKingOverhaul/Back Template.html
+++ b/Note Types/AnKingOverhaul/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -395,8 +395,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     
@@ -492,15 +492,16 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         extra.classList.add("hidden");
       }
       for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-        if (autoReveal) {
-          const container = document.querySelector(`[data-name="${field}"]`)
+        const container = document.querySelector(`[data-name="${field}"]`)
           if (container) {
-            const link = container.getElementsByTagName("a")[0]
-            const button = container.getElementsByTagName("button")[0]
-            const hint = container.getElementsByTagName("div")[0]
-            button.classList.remove("expanded-button")
-            hint.style.display = "none"
-            link.style.display = ""
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
+              const link = container.getElementsByTagName("a")[0]
+              const button = container.getElementsByTagName("button")[0]
+              const hint = container.getElementsByTagName("div")[0]
+              button.classList.remove("expanded-button")
+              hint.style.display = "none"
+              link.style.display = ""
           }
         }
       }
@@ -612,9 +613,10 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         // Also reveal autoReveal fields
         for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-          if (autoReveal) {
-            const container = document.querySelector(`[data-name="${field}"]`)
-            if (container) {
+          const container = document.querySelector(`[data-name="${field}"]`)
+          if (container) {
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
               const link = container.getElementsByTagName("a")[0]
               const button = container.getElementsByTagName("button")[0]
               const hint = container.getElementsByTagName("div")[0]
@@ -700,6 +702,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/AnKingOverhaul/Front Template.html
+++ b/Note Types/AnKingOverhaul/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -175,6 +175,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/Basic-AnKing/Back Template.html
+++ b/Note Types/Basic-AnKing/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -193,8 +193,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     
@@ -222,6 +222,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/Basic-AnKing/Front Template.html
+++ b/Note Types/Basic-AnKing/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <div id="front">{{edit:Front}}</div>
 
 <br>
@@ -138,6 +138,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/Basic-AnKingLanguage/Back Template.html
+++ b/Note Types/Basic-AnKingLanguage/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <script>
 // ##############  HINT REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -204,8 +204,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     
@@ -233,6 +233,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/Basic-AnKingLanguage/Front Template.html
+++ b/Note Types/Basic-AnKingLanguage/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <div id="front">{{edit:Front}}</div>
 
 <br>
@@ -138,6 +138,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/IO-one by one/Back Template.html
+++ b/Note Types/IO-one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";
@@ -161,6 +161,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 
@@ -259,8 +260,8 @@ var numTagLevelsToShow = 0;
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     

--- a/Note Types/IO-one by one/Front Template.html
+++ b/Note Types/IO-one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.
@@ -104,6 +104,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/Physeo-Cloze/Back Template.html
+++ b/Note Types/Physeo-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -244,8 +244,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     
@@ -341,15 +341,16 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         extra.classList.add("hidden");
       }
       for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-        if (autoReveal) {
-          const container = document.querySelector(`[data-name="${field}"]`)
+        const container = document.querySelector(`[data-name="${field}"]`)
           if (container) {
-            const link = container.getElementsByTagName("a")[0]
-            const button = container.getElementsByTagName("button")[0]
-            const hint = container.getElementsByTagName("div")[0]
-            button.classList.remove("expanded-button")
-            hint.style.display = "none"
-            link.style.display = ""
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
+              const link = container.getElementsByTagName("a")[0]
+              const button = container.getElementsByTagName("button")[0]
+              const hint = container.getElementsByTagName("div")[0]
+              button.classList.remove("expanded-button")
+              hint.style.display = "none"
+              link.style.display = ""
           }
         }
       }
@@ -461,9 +462,10 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         // Also reveal autoReveal fields
         for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-          if (autoReveal) {
-            const container = document.querySelector(`[data-name="${field}"]`)
-            if (container) {
+          const container = document.querySelector(`[data-name="${field}"]`)
+          if (container) {
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
               const link = container.getElementsByTagName("a")[0]
               const button = container.getElementsByTagName("button")[0]
               const hint = container.getElementsByTagName("div")[0]
@@ -549,6 +551,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/Physeo-Cloze/Front Template.html
+++ b/Note Types/Physeo-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -167,6 +167,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/Physeo-IO one by one/Back Template.html
+++ b/Note Types/Physeo-IO one by one/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <script>
 // ##############  OCCLUSION SHORTCUTS  ##############
 var RevealIncrementalShortcut = "N";
@@ -160,6 +160,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 
@@ -258,8 +259,8 @@ var numTagLevelsToShow = 0;
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     

--- a/Note Types/Physeo-IO one by one/Front Template.html
+++ b/Note Types/Physeo-IO one by one/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <script>
 // ############## USER CONFIGURATION START ##############
 // Auto flip to back when One by one mode.

--- a/Note Types/Sketchy-Cloze/Back Template.html
+++ b/Note Types/Sketchy-Cloze/Back Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
  <script>
 // ##############  BUTTON REVEAL SHORTCUTS  ##############
 // All shortcuts will also open with "H" if using the Hint Hotkeys add-on 
@@ -251,8 +251,8 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     
@@ -348,15 +348,16 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         extra.classList.add("hidden");
       }
       for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-        if (autoReveal) {
-          const container = document.querySelector(`[data-name="${field}"]`)
+        const container = document.querySelector(`[data-name="${field}"]`)
           if (container) {
-            const link = container.getElementsByTagName("a")[0]
-            const button = container.getElementsByTagName("button")[0]
-            const hint = container.getElementsByTagName("div")[0]
-            button.classList.remove("expanded-button")
-            hint.style.display = "none"
-            link.style.display = ""
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
+              const link = container.getElementsByTagName("a")[0]
+              const button = container.getElementsByTagName("button")[0]
+              const hint = container.getElementsByTagName("div")[0]
+              button.classList.remove("expanded-button")
+              hint.style.display = "none"
+              link.style.display = ""
           }
         }
       }
@@ -468,9 +469,10 @@ replace the arrows/dashes from the statement below with double curly brackets-->
         }
         // Also reveal autoReveal fields
         for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-          if (autoReveal) {
-            const container = document.querySelector(`[data-name="${field}"]`)
-            if (container) {
+          const container = document.querySelector(`[data-name="${field}"]`)
+          if (container) {
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
               const link = container.getElementsByTagName("a")[0]
               const button = container.getElementsByTagName("button")[0]
               const hint = container.getElementsByTagName("div")[0]
@@ -556,6 +558,7 @@ replace the arrows/dashes from the statement below with double curly brackets-->
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/Note Types/Sketchy-Cloze/Front Template.html
+++ b/Note Types/Sketchy-Cloze/Front Template.html
@@ -1,4 +1,4 @@
-<!-- version a9adf73 -->
+<!-- version 91d373c -->
 <div id="text">{{cloze:Text}}</div>
 
 <br>
@@ -167,6 +167,7 @@ var numTagLevelsToShow = 0;
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -102,15 +102,16 @@ _%>
         extra.classList.add("hidden");
       }
       for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-        if (autoReveal) {
-          const container = document.querySelector(`[data-name="${field}"]`)
+        const container = document.querySelector(`[data-name="${field}"]`)
           if (container) {
-            const link = container.getElementsByTagName("a")[0]
-            const button = container.getElementsByTagName("button")[0]
-            const hint = container.getElementsByTagName("div")[0]
-            button.classList.remove("expanded-button")
-            hint.style.display = "none"
-            link.style.display = ""
+            const tag = `autoopen::${containerId.substring(containerId.indexOf('-') + 1)}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
+              const link = container.getElementsByTagName("a")[0]
+              const button = container.getElementsByTagName("button")[0]
+              const hint = container.getElementsByTagName("div")[0]
+              button.classList.remove("expanded-button")
+              hint.style.display = "none"
+              link.style.display = ""
           }
         }
       }
@@ -222,9 +223,10 @@ _%>
         }
         // Also reveal autoReveal fields
         for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
-          if (autoReveal) {
-            const container = document.querySelector(`[data-name="${field}"]`)
-            if (container) {
+          const container = document.querySelector(`[data-name="${field}"]`)
+          if (container) {
+            const tag = `autoopen::${containerId.substring(containerId.indexOf('-') + 1)}`
+            if (autoReveal || globalThis.tagList.includes(tag)) {
               const link = container.getElementsByTagName("a")[0]
               const button = container.getElementsByTagName("button")[0]
               const hint = container.getElementsByTagName("div")[0]

--- a/src/components/clozeOneByOneBack.ejs
+++ b/src/components/clozeOneByOneBack.ejs
@@ -104,7 +104,7 @@ _%>
       for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
         const container = document.querySelector(`[data-name="${field}"]`)
           if (container) {
-            const tag = `autoopen::${containerId.substring(containerId.indexOf('-') + 1)}`
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
             if (autoReveal || globalThis.tagList.includes(tag)) {
               const link = container.getElementsByTagName("a")[0]
               const button = container.getElementsByTagName("button")[0]
@@ -225,7 +225,7 @@ _%>
         for (const [field, autoReveal] of Object.entries(ButtonAutoReveal)) {
           const container = document.querySelector(`[data-name="${field}"]`)
           if (container) {
-            const tag = `autoopen::${containerId.substring(containerId.indexOf('-') + 1)}`
+            const tag = `autoopen::${field.toLowerCase().replace(' ', '_')}`
             if (autoReveal || globalThis.tagList.includes(tag)) {
               const link = container.getElementsByTagName("a")[0]
               const button = container.getElementsByTagName("button")[0]

--- a/src/components/colorfulTags.ejs
+++ b/src/components/colorfulTags.ejs
@@ -17,6 +17,7 @@ _%>
   var tagContainer = document.getElementById("tags-container")
   if (tagContainer.childElementCount == 0) {
     var tagList = tagContainer.innerHTML.split(" ");
+    globalThis.tagList = tagList.map(t => t.toLowerCase());
     var kbdList = [];
     var newTagContent = document.createElement("div");
 

--- a/src/components/hintButtonsSetup.ejs
+++ b/src/components/hintButtonsSetup.ejs
@@ -69,8 +69,8 @@ _%>
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        
-        if (ButtonAutoReveal[fieldName]) {
+        const tag = `autoopen::${containerId.substring(containerId.indexOf('-') + 1)}`
+        if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }
     

--- a/src/components/hintButtonsSetup.ejs
+++ b/src/components/hintButtonsSetup.ejs
@@ -69,7 +69,7 @@ _%>
         const containerId = elem.id
         const fieldName = elem.dataset.name
         const button = elem.getElementsByClassName("button")[0]
-        const tag = `autoopen::${containerId.substring(containerId.indexOf('-') + 1)}`
+        const tag = `autoopen::${fieldName.toLowerCase().replace(' ', '_')}`
         if (ButtonAutoReveal[fieldName] || globalThis.tagList.includes(tag)) {
           toggleHintBtn(containerId, noScrolling=true)
         }


### PR DESCRIPTION
Closes #90
Closes #125 

~After this change, if a note has a tag named `autoopen::ln` for example, the hint field with the ID `hint-ln` (Personal Notes) will be revealed. We can't use the field names here since they contain spaces. 
Maybe the IDs of all hint fields should be documented somewhere.~
After this change, if a note has a tag named `autoopen::Personal_Notes` for example, Personal Notes will be revealed.


@AnKingMed